### PR TITLE
Add a few compilation flags

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,5 +3,5 @@
 set GO111MODULE=on
 
 cd %SRC_DIR%
-go build -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge" -trimpath -v -o %LIBRARY_PREFIX%\bin\hugo.exe
+go build -buildmode=exe -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge" -trimpath -v -o %LIBRARY_PREFIX%\bin\hugo.exe
 go-licenses save . --save_path .\library_licenses

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,5 +3,5 @@
 set GO111MODULE=on
 
 cd %SRC_DIR%
-go build -ldflags "-X main.revision=conda-forge" -v -o %LIBRARY_PREFIX%\bin\hugo.exe
+go build -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge" -trimpath -v -o %LIBRARY_PREFIX%\bin\hugo.exe
 go-licenses save . --save_path .\library_licenses

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,5 +5,5 @@ set -ex
 export GO111MODULE=on
 
 cd $SRC_DIR
-go build -ldflags "-X main.revision=conda-forge" -v -o $PREFIX/bin/hugo
+go build -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge" -trimpath -v -o $PREFIX/bin/hugo
 go-licenses save . --save_path ./library_licenses

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
 test:
   commands:
     - hugo help
+    - hugo version
 
 about:
   home: https://gohugo.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a75c4c684d2125255f214d11b9834a5ec6eb64353f4de2c06952d2b3b7430f0e
 
 build:
-  number: 0
+  number: 1
   binary_relocation: false
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

<hr>

This PR adds a few more compilation flags to the `go build` command:

1. `-s -w` added to the linker flags for building smaller binaries (`-s` disables the symbol table and `-w` disables DWARF generation, i.e., debugging information)
2. `-X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge` embeds the vendor information in the executable, which can be accessed using `hugo version` or similar – this is derived from the [Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/cdfc83ac90c8193a43685ca3fb01576519db5bac/Formula/h/hugo.rb#L30) for Hugo 
3. `-trimpath` removes a few strings related to the paths from the binaries, see: https://github.com/gohugoio/hugo/issues/12406#issuecomment-2225708000, https://github.com/agriyakhetarpal/hugo-python-distributions/pull/125

P.S. The list of dependencies contains a C compiler, but this project doesn't build the extended version of Hugo yet. Maybe it would make sense to build it (either here or in a separate, new feedstock)?