### PR TITLE
Build with `extended,withdeploy` tags

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,5 +4,5 @@ set GO111MODULE=on
 set CGO_ENABLED=1
 
 cd %SRC_DIR%
-go build -buildmode=exe -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge -extldflags '-static'" -tags extended -trimpath -v -o %LIBRARY_PREFIX%\bin\hugo.exe || exit 1
+go build -buildmode=exe -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge -extldflags '-static'" -tags extended,withdeploy -trimpath -v -o %LIBRARY_PREFIX%\bin\hugo.exe || exit 1
 go-licenses save . --save_path .\library_licenses || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,6 @@ export GO111MODULE=on
 export CGO_ENABLED=1
 
 cd $SRC_DIR
-go build -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge" -tags extended -trimpath -v -o $PREFIX/bin/hugo
+go build -ldflags "-s -w -X main.revision=conda-forge -X github.com/gohugoio/hugo/common/hugo.vendorInfo=conda-forge" -tags extended,withdeploy -trimpath -v -o $PREFIX/bin/hugo
 go-licenses save . --save_path ./library_licenses
 chmod -R u+w $(go env GOPATH) && rm -r $(go env GOPATH)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 641133ac7cb3ddaec76383ec5ed023e26e652b3c4aafd8eb0ff1ed1995e47aa3
 
 build:
-  number: 0
+  number: 1
   binary_relocation: false
   # Hugo binaries are statically linked on Windows, so the
   # following silences some warnings from conda-forge about
@@ -36,7 +36,7 @@ test:
 about:
   home: https://gohugo.io/
   dev_url: https://github.com/gohugoio/hugo
-  summary: The extended version of the Hugo static site generator – the world's fastest framework for building websites.
+  summary: The extended + withdeploy version of the Hugo static site generator – the world's fastest framework for building websites.
   license: Apache-2.0
   license_file:
     - LICENSE


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

https://github.com/gohugoio/hugo/releases/tag/v0.137.0 has split off the `nodeploy` tag into a separate `extended` + `withdeploy` binary to shave 40% off binary size. We include this to be feature complete and retain original features and not introduce another feedstock . Let me know if you have any concerns, @dbast and @moritzwilksch! I did the same thing in https://github.com/agriyakhetarpal/hugo-python-distributions/pull/90 yesterday.

The Hugo documentation reflects the new edition split here: https://gohugo.io/installation/linux/#editions